### PR TITLE
support for img2img

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -6,6 +6,7 @@ import torch
 from cog import BasePredictor, Input, Path
 from diffusers import (
     StableDiffusionPipeline,
+    StableDiffusionImg2ImgPipeline,
     PNDMScheduler,
     LMSDiscreteScheduler,
     DDIMScheduler,
@@ -16,6 +17,7 @@ from diffusers import (
 from diffusers.pipelines.stable_diffusion.safety_checker import (
     StableDiffusionSafetyChecker,
 )
+from PIL import Image
 from transformers import CLIPFeatureExtractor
 
 
@@ -58,11 +60,21 @@ class Predictor(BasePredictor):
         )
 
         print("Loading SD pipeline...")
-        self.pipe = StableDiffusionPipeline.from_pretrained(
+        self.txt2img_pipe = StableDiffusionPipeline.from_pretrained(
             "weights",
             safety_checker=self.safety_checker,
             feature_extractor=feature_extractor,
             torch_dtype=torch.float16,
+        ).to("cuda")
+
+        self.img2img_pipe = StableDiffusionImg2ImgPipeline(
+            vae=self.txt2img_pipe.vae,
+            text_encoder=self.txt2img_pipe.text_encoder,
+            tokenizer=self.txt2img_pipe.tokenizer,
+            unet=self.txt2img_pipe.unet,
+            scheduler=self.txt2img_pipe.scheduler,
+            safety_checker=self.txt2img_pipe.safety_checker,
+            feature_extractor=self.txt2img_pipe.feature_extractor,
         ).to("cuda")
 
     @torch.inference_mode()
@@ -75,6 +87,10 @@ class Predictor(BasePredictor):
         negative_prompt: str = Input(
             description="Specify things to not see in the output",
             default=None,
+        ),
+        image: Path = Input(
+            description="Inital image to generate variations of. This enables img2img! Ensure your images are reasonably sized as the output is the same size as your input image (height and width input parameters are ignored).",
+            default=None
         ),
         width: int = Input(
             description="Width of output image. Maximum size is 1024x768 or 768x1024 because of memory limits",
@@ -131,25 +147,39 @@ class Predictor(BasePredictor):
                 "Maximum size is 1024x768 or 768x1024 pixels, because of memory limits. Please select a lower width or height."
             )
 
-        self.pipe.scheduler = make_scheduler(scheduler, self.pipe.scheduler.config)
+        if image is not None:
+            print("using img2img")
+            pipe = self.img2img_pipe
+            extra_kwargs = {
+                "image": Image.open(image).convert("RGB"),
+                "strength": prompt_strength,
+            }
+        else:
+            print("using txt2img")
+            pipe = self.txt2img_pipe
+            extra_kwargs = {
+                "width": width,
+                "height": height,
+            }
+
+        pipe.scheduler = make_scheduler(scheduler, pipe.scheduler.config)
 
         generator = torch.Generator("cuda").manual_seed(seed)
 
         if disable_safety_check:
-            self.pipe.safety_checker = None
+            pipe.safety_checker = None
         else:
-            self.pipe.safety_checker = self.safety_checker
+            pipe.safety_checker = self.safety_checker
 
-        output = self.pipe(
+        output = pipe(
             prompt=[prompt] * num_outputs if prompt is not None else None,
             negative_prompt=[negative_prompt] * num_outputs
             if negative_prompt is not None
             else None,
-            width=width,
-            height=height,
             guidance_scale=guidance_scale,
             generator=generator,
             num_inference_steps=num_inference_steps,
+            **extra_kwargs,
         )
 
         output_paths = []

--- a/predict.py
+++ b/predict.py
@@ -89,7 +89,7 @@ class Predictor(BasePredictor):
             default=None,
         ),
         image: Path = Input(
-            description="Inital image to generate variations of. This enables img2img! Ensure your images are reasonably sized as the output is the same size as your input image (height and width input parameters are ignored).",
+            description="A starting image from which to generate variations (aka 'img2img'). If this input is set, the `width` and `height` inputs are ignored and the output will have the same dimensions as the input image."
             default=None
         ),
         width: int = Input(


### PR DESCRIPTION
Based on @chenxwh work on img2img for SD2.1, this adds img2img to generated dreambooths!

As the output image is the same size as the input image:

- be sure to resize to a reasonable size (512px-1024px per side)
- width and height inputs are ignored

Example using https://replicate.com/zeke/zekebooth weights

Input:

![base](https://user-images.githubusercontent.com/27/210173619-2b3108d6-976e-471b-b7b8-b32b73317e1b.jpg)

Output:

![zeke](https://user-images.githubusercontent.com/27/210173447-0e774d8c-7742-4990-87ff-b9e50b8c0d98.png)
